### PR TITLE
remove  `get_`  in getter function 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use crate::pack::{get_pack_context, get_pack_name};
-use crate::unpack::get_unpack_context;
+use crate::pack::{pack_context, pack_name};
+use crate::unpack::unpack_context;
 use clap::Parser;
 use crate_spec::utils::context::SIGTYPE;
 use crate_spec::utils::pkcs::PKCS;
@@ -9,6 +9,7 @@ use std::str::FromStr;
 
 pub mod pack;
 pub mod unpack;
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -59,7 +60,7 @@ fn main() {
         }
 
         //pack package
-        let mut pack_context = get_pack_context(&args.input);
+        let mut pack_context = pack_context(&args.input);
 
         //sign package
         let mut pkcs = PKCS::new();
@@ -75,7 +76,7 @@ fn main() {
 
         //dump binary path/<name>.scrate
         let mut bin_path = PathBuf::from_str(args.output.as_str()).unwrap();
-        bin_path.push(get_pack_name(&pack_context));
+        bin_path.push(pack_name(&pack_context));
         fs::write(bin_path, bin).unwrap();
     } else if !args.encode && args.decode {
         //check args
@@ -92,7 +93,7 @@ fn main() {
         }
 
         //decode package from binary
-        let pack_context = get_unpack_context(args.input.as_str(), args.root_ca_paths);
+        let pack_context = unpack_context(args.input.as_str(), args.root_ca_paths);
         if pack_context.is_err() {
             eprintln!("{}", pack_context.unwrap_err());
             return;
@@ -119,7 +120,7 @@ fn main() {
                 pack_context.pack_info, pack_context.dep_infos
             ),
         )
-        .unwrap();
+            .unwrap();
     } else {
         eprintln!("-e or -d not found!");
         return;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -74,23 +74,23 @@ impl Packing {
         self.pack_context.add_crate_bin(bin);
     }
 
-    fn get_pack_context(mut self) -> PackageContext {
+    fn pack_context(mut self) -> PackageContext {
         self.cmd_cargo_package();
         self.read_crate();
         self.pack_context
     }
 }
 
-pub fn get_pack_context(path: &str) -> PackageContext {
-    Packing::new(path).get_pack_context()
+pub fn pack_context(path: &str) -> PackageContext {
+    Packing::new(path).pack_context()
 }
 
-pub fn get_pack_name(pack: &PackageContext) -> String {
+pub fn pack_name(pack: &PackageContext) -> String {
     format!("{}-{}.scrate", pack.pack_info.name, pack.pack_info.version)
 }
 
 #[test]
 fn test_cmd_cargo_package() {
-    let pac = get_pack_context("../crate-spec");
+    let pac = pack_context("../crate-spec");
     println!("{:#?}", pac);
 }

--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -71,7 +71,7 @@ impl PackageContext {
         });
     }
 
-    pub fn get_dep_num(&self) -> usize {
+    pub fn dep_num(&self) -> usize {
         self.dep_infos.len()
     }
 
@@ -86,7 +86,7 @@ impl PackageContext {
         self.sigs.len() - 1
     }
 
-    pub fn get_sig_num(&self) -> usize {
+    pub fn sig_num(&self) -> usize {
         self.sigs.len()
     }
 
@@ -153,12 +153,12 @@ impl PackageInfo {
     }
 
     pub fn read_from_package_section(&mut self, ps: &PackageSection, str_table: &StringTable) {
-        self.name = str_table.get_str_by_off(&ps.pkg_name);
-        self.version = str_table.get_str_by_off(&ps.pkg_version);
-        self.license = str_table.get_str_by_off(&ps.pkg_license);
+        self.name = str_table.str_by_off(&ps.pkg_name);
+        self.version = str_table.str_by_off(&ps.pkg_version);
+        self.license = str_table.str_by_off(&ps.pkg_license);
         let authors_off = ps.pkg_authors.to_vec();
         authors_off.iter().for_each(|author_off| {
-            self.authors.push(str_table.get_str_by_off(author_off));
+            self.authors.push(str_table.str_by_off(author_off));
         });
     }
 }
@@ -233,29 +233,29 @@ impl DepInfo {
 
     pub fn read_from_dep_table_entry(&mut self, dte: &DepTableEntry, str_table: &StringTable) {
         self.dump = true;
-        self.name = str_table.get_str_by_off(&dte.dep_name);
-        self.ver_req = str_table.get_str_by_off(&dte.dep_verreq);
+        self.name = str_table.str_by_off(&dte.dep_name);
+        self.ver_req = str_table.str_by_off(&dte.dep_verreq);
         match dte.dep_srctype {
             0 => {
                 self.src = SrcTypePath::CratesIo;
             }
             1 => {
-                self.src = SrcTypePath::Git(str_table.get_str_by_off(&dte.dep_srcpath));
+                self.src = SrcTypePath::Git(str_table.str_by_off(&dte.dep_srcpath));
             }
             2 => {
-                self.src = SrcTypePath::Url(str_table.get_str_by_off(&dte.dep_srcpath));
+                self.src = SrcTypePath::Url(str_table.str_by_off(&dte.dep_srcpath));
             }
             3 => {
-                self.src = SrcTypePath::Registry(str_table.get_str_by_off(&dte.dep_srcpath));
+                self.src = SrcTypePath::Registry(str_table.str_by_off(&dte.dep_srcpath));
             }
             4 => {
-                self.src = SrcTypePath::P2p(str_table.get_str_by_off(&dte.dep_srcpath));
+                self.src = SrcTypePath::P2p(str_table.str_by_off(&dte.dep_srcpath));
             }
             _ => {
                 panic!("dep_srctype not valid!")
             }
         }
-        self.src_platform = str_table.get_str_by_off(&dte.dep_platform);
+        self.src_platform = str_table.str_by_off(&dte.dep_platform);
     }
 }
 
@@ -310,11 +310,11 @@ impl StringTable {
         self.str2off.contains_key(st)
     }
 
-    pub fn get_off_by_str(&self, st: &String) -> u32 {
+    pub fn off_by_str(&self, st: &String) -> u32 {
         *self.str2off.get(st).unwrap()
     }
 
-    pub fn get_str_by_off(&self, off: &u32) -> String {
+    pub fn str_by_off(&self, off: &u32) -> String {
         self.off2str.get(off).unwrap().clone()
     }
 

--- a/src/utils/decode.rs
+++ b/src/utils/decode.rs
@@ -7,7 +7,7 @@ use crate::utils::package::{
 use crate::utils::pkcs::PKCS;
 
 impl SectionIndex {
-    pub fn get_section_id_by_typ(&self, typ: usize) -> usize {
+    pub fn section_id_by_type(&self, typ: usize) -> usize {
         for (i, entry) in self.entries.arr.iter().enumerate() {
             if entry.sh_type as usize == typ {
                 return i;
@@ -18,17 +18,17 @@ impl SectionIndex {
 }
 
 impl CratePackage {
-    pub fn get_data_section_by_id(&self, id: usize) -> &DataSection {
+    pub fn data_section_by_id(&self, id: usize) -> &DataSection {
         &self.data_sections.col.arr[id]
     }
 
-    pub fn get_data_section_by_typ(&self, typ: usize) -> &DataSection {
-        self.get_data_section_by_id(self.section_index.get_section_id_by_typ(typ))
+    pub fn data_section_by_type(&self, typ: usize) -> &DataSection {
+        self.data_section_by_id(self.section_index.section_id_by_type(typ))
     }
 
-    pub fn get_package_section(&self) -> &PackageSection {
+    pub fn package_section(&self) -> &PackageSection {
         //FIXME: 0 should be constant
-        match self.get_data_section_by_typ(0) {
+        match self.data_section_by_type(0) {
             DataSection::PackageSection(pak) => pak,
             _ => {
                 panic!("package section not found!")
@@ -36,8 +36,8 @@ impl CratePackage {
         }
     }
 
-    pub fn get_dep_table_section(&self) -> &DepTableSection {
-        match self.get_data_section_by_typ(1) {
+    pub fn dep_table_section(&self) -> &DepTableSection {
+        match self.data_section_by_type(1) {
             DataSection::DepTableSection(dep) => dep,
             _ => {
                 panic!("dep table section not found!")
@@ -45,8 +45,8 @@ impl CratePackage {
         }
     }
 
-    pub fn get_crate_binary_section(&self) -> &CrateBinarySection {
-        match self.get_data_section_by_typ(3) {
+    pub fn crate_binary_section(&self) -> &CrateBinarySection {
+        match self.data_section_by_type(3) {
             DataSection::CrateBinarySection(cra) => cra,
             _ => {
                 panic!("crate binary section not found!")
@@ -54,9 +54,9 @@ impl CratePackage {
         }
     }
 
-    pub fn get_sig_structure_section(&self, no: usize) -> &SigStructureSection {
-        let base = self.section_index.get_section_id_by_typ(4);
-        match self.get_data_section_by_id(no + base) {
+    pub fn sig_structure_section(&self, no: usize) -> &SigStructureSection {
+        let base = self.section_index.section_id_by_type(4);
+        match self.data_section_by_id(no + base) {
             DataSection::SigStructureSection(sig) => sig,
             _ => {
                 panic!("sig structure section not found!")
@@ -66,18 +66,18 @@ impl CratePackage {
 }
 
 impl PackageContext {
-    pub fn get_binary_before_sig(&self, crate_package: &CratePackage, bin: &[u8]) -> Vec<u8> {
+    pub fn binary_before_sig(&self, crate_package: &CratePackage, bin: &[u8]) -> Vec<u8> {
         //FIXME
         let ds_size = crate_package
             .section_index
-            .get_datasection_size_without_sig();
+            .datasection_size_without_sig();
         let total_size = crate_package.crate_header.ds_offset as usize + ds_size;
-        if crate_package.section_index.get_sig_num() != self.sigs.len() && !self.sigs.is_empty() {
-            assert_eq!(crate_package.section_index.get_sig_num(), 0);
+        if crate_package.section_index.sig_num() != self.sigs.len() && !self.sigs.is_empty() {
+            assert_eq!(crate_package.section_index.sig_num(), 0);
         }
         let mut buf = bin[..total_size].to_vec();
         let zero_begin = crate_package.crate_header.si_offset as usize
-            + crate_package.section_index.get_none_sig_size();
+            + crate_package.section_index.none_sig_size();
         let zero_end = crate_package.crate_header.si_offset as usize
             + crate_package.crate_header.si_size as usize;
         //FIXME this is not efficient
@@ -88,31 +88,31 @@ impl PackageContext {
         buf
     }
 
-    pub fn get_binary_before_digest(&self, bin: &[u8]) -> Vec<u8> {
+    pub fn binary_before_digest(&self, bin: &[u8]) -> Vec<u8> {
         bin[..bin.len() - FINGERPRINT_LEN].to_vec()
     }
 
-    fn get_pack_info(&mut self, crate_package: &CratePackage, str_table: &StringTable) {
+    fn pack_info(&mut self, crate_package: &CratePackage, str_table: &StringTable) {
         self.pack_info
-            .read_from_package_section(crate_package.get_package_section(), str_table);
+            .read_from_package_section(crate_package.package_section(), str_table);
     }
 
-    fn get_deps(&mut self, crate_package: &CratePackage, str_table: &StringTable) {
-        for entry in crate_package.get_dep_table_section().entries.arr.iter() {
+    fn deps(&mut self, crate_package: &CratePackage, str_table: &StringTable) {
+        for entry in crate_package.dep_table_section().entries.arr.iter() {
             let mut dep_info = DepInfo::default();
             dep_info.read_from_dep_table_entry(entry, str_table);
             self.dep_infos.push(dep_info);
         }
     }
 
-    fn get_binary(&mut self, crate_package: &CratePackage) {
-        self.crate_binary.bytes = crate_package.get_crate_binary_section().bin.arr.clone();
+    fn binary(&mut self, crate_package: &CratePackage) {
+        self.crate_binary.bytes = crate_package.crate_binary_section().bin.arr.clone();
     }
 
-    fn get_sigs(&mut self, crate_package: &CratePackage) {
-        let sig_num = crate_package.section_index.get_sig_num();
+    fn sigs(&mut self, crate_package: &CratePackage) {
+        let sig_num = crate_package.section_index.sig_num();
         for no in 0..sig_num {
-            let sig = crate_package.get_sig_structure_section(no);
+            let sig = crate_package.sig_structure_section(no);
             let mut sig_info = SigInfo::new();
             sig_info.bin = sig.sigstruct_sig.arr.clone();
             sig_info.size = sig.sigstruct_size as usize;
@@ -127,8 +127,8 @@ impl PackageContext {
     }
 
     fn check_sigs(&self, crate_package: &CratePackage, bin_all: &[u8]) -> bool {
-        let bin_all = self.get_binary_before_sig(crate_package, bin_all);
-        let bin_crate = crate_package.get_crate_binary_section().bin.arr.as_slice();
+        let bin_all = self.binary_before_sig(crate_package, bin_all);
+        let bin_crate = crate_package.crate_binary_section().bin.arr.as_slice();
         for siginfo in self.sigs.iter() {
             let actual_digest;
             //FIXME this should be encapsulated as it's used in encode as well
@@ -161,10 +161,10 @@ impl PackageContext {
         let crate_package = CratePackage::decode_from_slice(bin)?;
         let mut str_table = StringTable::new();
         str_table.read_bytes(crate_package.string_table.arr.as_slice());
-        self.get_pack_info(&crate_package, &str_table);
-        self.get_deps(&crate_package, &str_table);
-        self.get_binary(&crate_package);
-        self.get_sigs(&crate_package);
+        self.pack_info(&crate_package, &str_table);
+        self.deps(&crate_package, &str_table);
+        self.binary(&crate_package);
+        self.sigs(&crate_package);
         if !self.check_sigs(&crate_package, bin) {
             return Err("file sig not right".to_string());
         }
@@ -175,7 +175,7 @@ impl PackageContext {
 #[test]
 fn test_encode_decode() {
     use crate::utils::context::{PackageInfo, SrcTypePath, SIGTYPE};
-    fn get_pack_info() -> PackageInfo {
+    fn pack_info() -> PackageInfo {
         PackageInfo {
             name: "rust-crate".to_string(),
             version: "1.0.0".to_string(),
@@ -184,7 +184,7 @@ fn test_encode_decode() {
         }
     }
 
-    fn get_dep_info1() -> DepInfo {
+    fn dep_info1() -> DepInfo {
         DepInfo {
             name: "toml".to_string(),
             ver_req: "1.0.0".to_string(),
@@ -194,7 +194,7 @@ fn test_encode_decode() {
         }
     }
 
-    fn get_dep_info2() -> DepInfo {
+    fn dep_info2() -> DepInfo {
         DepInfo {
             name: "crate-spec".to_string(),
             ver_req: ">=0.8.0".to_string(),
@@ -204,11 +204,11 @@ fn test_encode_decode() {
         }
     }
 
-    fn get_crate_binary() -> Vec<u8> {
+    fn crate_binary() -> Vec<u8> {
         [15; 100].to_vec()
     }
 
-    fn get_sign() -> PKCS {
+    fn sign() -> PKCS {
         let mut pkcs1 = PKCS::new();
         pkcs1.load_from_file_writer(
             "test/cert.pem".to_string(),
@@ -220,25 +220,25 @@ fn test_encode_decode() {
 
     let mut package_context = PackageContext::new();
 
-    package_context.pack_info = get_pack_info();
-    package_context.dep_infos.push(get_dep_info1());
-    package_context.dep_infos.push(get_dep_info2());
-    package_context.crate_binary.bytes = get_crate_binary();
-    package_context.add_sig(get_sign(), SIGTYPE::CRATEBIN);
-    package_context.add_sig(get_sign(), SIGTYPE::FILE);
+    package_context.pack_info = pack_info();
+    package_context.dep_infos.push(dep_info1());
+    package_context.dep_infos.push(dep_info2());
+    package_context.crate_binary.bytes = crate_binary();
+    package_context.add_sig(sign(), SIGTYPE::CRATEBIN);
+    package_context.add_sig(sign(), SIGTYPE::FILE);
 
     let (_crate_package, _str_table, bin) = package_context.encode_to_crate_package();
 
     let mut package_context_new = PackageContext::new();
-    package_context_new.set_root_cas_bin(PKCS::get_root_ca_bins(
+    package_context_new.set_root_cas_bin(PKCS::root_ca_bins(
         ["test/root-ca.pem".to_string()].to_vec(),
     ));
     let (_crate_package_new, _str_table) = package_context_new
         .decode_from_crate_package(bin.as_slice())
         .unwrap();
 
-    assert_eq!(get_pack_info(), package_context_new.pack_info);
-    assert_eq!(get_dep_info1(), package_context_new.dep_infos[0]);
-    assert_eq!(get_dep_info2(), package_context_new.dep_infos[1]);
-    assert_eq!(get_crate_binary(), package_context_new.crate_binary.bytes);
+    assert_eq!(pack_info(), package_context_new.pack_info);
+    assert_eq!(dep_info1(), package_context_new.dep_infos[0]);
+    assert_eq!(dep_info2(), package_context_new.dep_infos[1]);
+    assert_eq!(crate_binary(), package_context_new.crate_binary.bytes);
 }

--- a/src/utils/package/gen_bincode.rs
+++ b/src/utils/package/gen_bincode.rs
@@ -363,37 +363,37 @@ impl CrateBinarySection {
 
 //get_size
 impl CrateHeader {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 }
 
 impl<T: Encode + 'static> RawArrayType<T> {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 }
 
 impl SectionIndex {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 
-    pub fn get_num(&self) -> usize {
+    pub fn num(&self) -> usize {
         self.entries.arr.len()
     }
 
-    pub fn get_none_sig_size(&self) -> usize {
+    pub fn none_sig_size(&self) -> usize {
         let mut total_len = 0;
         self.entries.arr.iter().for_each(|x| {
             if x.sh_type != 4 {
-                total_len += x.get_size();
+                total_len += x.size();
             }
         });
         total_len
     }
 
-    pub fn get_none_sig_num(&self) -> usize {
+    pub fn none_sig_num(&self) -> usize {
         let mut total_len = 0;
         self.entries.arr.iter().for_each(|x| {
             if x.sh_type != 4 {
@@ -403,12 +403,12 @@ impl SectionIndex {
         total_len
     }
 
-    pub fn get_sig_num(&self) -> usize {
-        self.get_num() - self.get_none_sig_num()
+    pub fn sig_num(&self) -> usize {
+        self.num() - self.none_sig_num()
     }
 
-    pub fn get_sig_size(&self) -> usize {
-        self.get_size() - self.get_none_sig_size()
+    pub fn sig_size(&self) -> usize {
+        self.size() - self.none_sig_size()
     }
 
     pub fn encode_fake_to_vec(&self, no_sig_size: usize, size: usize) -> Vec<u8> {
@@ -418,44 +418,44 @@ impl SectionIndex {
         buf
     }
 
-    pub fn get_datasection_size_without_sig(&self) -> usize {
-        (self.entries.arr[self.get_none_sig_num() - 1].sh_offset
-            + self.entries.arr[self.get_none_sig_num() - 1].sh_size) as usize
+    pub fn datasection_size_without_sig(&self) -> usize {
+        (self.entries.arr[self.none_sig_num() - 1].sh_offset
+            + self.entries.arr[self.none_sig_num() - 1].sh_size) as usize
     }
 }
 
 impl DataSectionCollectionType {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 }
 
 impl PackageSection {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 }
 
 impl DepTableSection {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 }
 
 impl CrateBinarySection {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 }
 
 impl SigStructureSection {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 }
 
 impl SectionIndexEntry {
-    pub fn get_size(&self) -> usize {
+    pub fn size(&self) -> usize {
         encode_size_by_bincode(self)
     }
 }

--- a/src/utils/package/mod.rs
+++ b/src/utils/package/mod.rs
@@ -276,7 +276,7 @@ pub enum DataSection {
     SigStructureSection(SigStructureSection),
 }
 
-pub fn get_datasection_type(d: &DataSection) -> Type {
+pub fn datasection_type(d: &DataSection) -> Type {
     match d {
         DataSection::PackageSection(_) => 0,
         DataSection::DepTableSection(_) => 1,

--- a/src/utils/pkcs.rs
+++ b/src/utils/pkcs.rs
@@ -31,7 +31,7 @@ impl PKCS {
             root_ca_bins: vec![],
         }
     }
-    pub fn get_root_ca_bins(ca_paths: Vec<String>) -> Vec<Vec<u8>> {
+    pub fn root_ca_bins(ca_paths: Vec<String>) -> Vec<Vec<u8>> {
         let mut root_ca_bins = vec![];
         for ca_path in ca_paths {
             root_ca_bins.push(fs::read(Path::new(ca_path.as_str())).unwrap());


### PR DESCRIPTION
According to   https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter ,
The get_ prefix is not used for getters in Rust code, this PR fix it 
